### PR TITLE
Make flit install succeed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
-    "Framework :: Django :: 5.1",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ basepython = python3.10
 
 deps =
     wagtail>=5.1
+    .[testing]
 
 commands_pre =
     python {toxinidir}/testmanage.py makemigrations


### PR DESCRIPTION
- prompts.py import Django and the Flit installation script has no Django installed.
- `Framework :: Django :: 5.1` is supposedly an invalid classifier.