### PR TITLE
Update flit sdist config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,14 +66,17 @@ pythonpath = ["./", "./tests"]
 
 [tool.flit.sdist]
 include = [
-    "wagtail_ai/static"
+    "src/wagtail_ai/static/wagtail_ai"
 ]
 exclude = [
-    "wagtail_ai/static_src",
-    "wagtail_ai/test",
-    "wagtail_ai/static/wagtail_ai/js/.gitignore",
+    "docs",
+    "src/wagtail_ai/static_src",
+    "src/wagtail_ai/static/wagtail_ai/js/.gitignore",
     "tests",
     "testmanage.py",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "TODOs",
     ".*",
     "*.js",
     "*.json",


### PR DESCRIPTION
This updates the sdist configuration to match the updated directory structure, and exclude a few extra files.

The most important bit is the need to include the built static assets