### PR TITLE
More defensive prompt view handling

### DIFF
--- a/src/wagtail_ai/forms.py
+++ b/src/wagtail_ai/forms.py
@@ -1,0 +1,40 @@
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+
+class PromptTextField(forms.CharField):
+    default_error_messages = {
+        "required": _(
+            "No text provided - please enter some text before using AI features."
+        ),
+    }
+
+
+class PromptUUIDField(forms.UUIDField):
+    default_error_messages = {
+        "required": _("Invalid prompt provided."),
+        "invalid": _("Invalid prompt provided."),
+    }
+
+
+class PromptForm(forms.Form):
+    text = PromptTextField()
+    prompt = PromptUUIDField()
+
+    def clean_prompt(self):
+        prompt_uuid = self.cleaned_data["prompt"]
+        if prompt_uuid.version != 4:
+            raise ValidationError(
+                self.fields["prompt"].error_messages["invalid"], code="invalid"
+            )
+
+        return prompt_uuid
+
+    def errors_for_json_response(self) -> str:
+        errors_for_response = []
+        for _field, errors in self.errors.get_json_data().items():
+            for error in errors:
+                errors_for_response.append(error["message"])
+
+        return " \n".join(errors_for_response)

--- a/src/wagtail_ai/views.py
+++ b/src/wagtail_ai/views.py
@@ -4,6 +4,7 @@ import uuid
 
 from django import forms
 from django.http import JsonResponse
+from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 from wagtail.admin.ui.tables import UpdatedAtColumn
 from wagtail.admin.viewsets.model import ModelViewSet
@@ -87,18 +88,19 @@ def process(request) -> JsonResponse:
     text = request.POST.get("text", "").strip()
 
     if not text:
-        error = "No text provided - please enter some text before using AI features."
+        error = _("No text provided - please enter some text before using AI features.")
         return JsonResponse({"error": error}, status=400)
 
+    invalid_prompt_error = _("Invalid prompt provided.")
     prompt_id = request.POST.get("prompt", "").strip()
 
     if not _is_prompt_id_valid(prompt_id):
-        return JsonResponse({"error": "Invalid prompt provided"}, status=400)
+        return JsonResponse({"error": invalid_prompt_error}, status=400)
 
     try:
         prompt = Prompt.objects.get(uuid=prompt_id)
     except Prompt.DoesNotExist:
-        return JsonResponse({"error": "Invalid prompt provided"}, status=400)
+        return JsonResponse({"error": invalid_prompt_error}, status=400)
 
     handlers = {
         Prompt.Method.REPLACE: _replace_handler,
@@ -113,7 +115,7 @@ def process(request) -> JsonResponse:
         return JsonResponse({"error": str(e)}, status=400)
     except Exception:
         logger.exception("An unexpected error occurred.")
-        return JsonResponse({"error": "An unexpected error occurred"}, status=500)
+        return JsonResponse({"error": _("An unexpected error occurred.")}, status=500)
 
     return JsonResponse({"message": response})
 

--- a/src/wagtail_ai/views.py
+++ b/src/wagtail_ai/views.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from django import forms
+from django.core.exceptions import ValidationError
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from wagtail.admin.ui.tables import UpdatedAtColumn
@@ -84,7 +85,7 @@ def process(request):
 
     try:
         prompt = Prompt.objects.get(uuid=prompt_id)
-    except Prompt.DoesNotExist:
+    except (Prompt.DoesNotExist, ValidationError):
         return JsonResponse({"error": "Invalid prompt provided"}, status=400)
 
     handlers = {

--- a/src/wagtail_ai/views.py
+++ b/src/wagtail_ai/views.py
@@ -77,13 +77,8 @@ def process(request):
     text = request.POST.get("text")
 
     if not text:
-        return JsonResponse(
-            {
-                "error": "No text provided - please enter some text before using AI \
-                    features"
-            },
-            status=400,
-        )
+        error = "No text provided - please enter some text before using AI features."
+        return JsonResponse({"error": error}, status=400)
 
     prompt_id = request.POST.get("prompt")
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -47,7 +47,8 @@ def test_process_view_get_request(client, setup_users):
     response = client.get(url)
     assert response.status_code == 400
     assert response.json() == {
-        "error": "No text provided - please enter some text before using AI features."
+        "error": "No text provided - please enter some text before using AI features. "
+        "\nInvalid prompt provided."
     }
 
 
@@ -61,12 +62,15 @@ def test_process_view_post_without_text(client, setup_users):
     response = client.post(url, data={})
     assert response.status_code == 400
     assert response.json() == {
-        "error": "No text provided - please enter some text before using AI features."
+        "error": "No text provided - please enter some text before using AI features. "
+        "\nInvalid prompt provided."
     }
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("prompt", [None, "NOT-A-UUID", str(uuid.uuid4())])
+@pytest.mark.parametrize(
+    "prompt", [None, "NOT-A-UUID", str(uuid.uuid1()), str(uuid.uuid4())]
+)
 def test_process_view_with_bad_prompt_id(client, setup_users, prompt):
     url = reverse("wagtail_ai:process")
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -79,7 +79,7 @@ def test_process_view_with_bad_prompt_id(client, setup_users, prompt):
 
     response = client.post(url, data=data)
     assert response.status_code == 400
-    assert response.json() == {"error": "Invalid prompt provided"}
+    assert response.json() == {"error": "Invalid prompt provided."}
 
 
 @pytest.mark.django_db

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from django.urls import reverse
 from wagtail_ai.views import PromptEditForm, prompt_viewset
@@ -35,4 +37,61 @@ def test_prompt_model_admin_viewset_edit_view(client, setup_users, setup_prompt_
     assert setup_prompt_object.label in str(response.content)
 
 
-# TODO add tests for process view
+@pytest.mark.django_db
+def test_process_view_get_request(client, setup_users):
+    url = reverse("wagtail_ai:process")
+
+    superuser = setup_users
+    client.force_login(superuser)
+
+    response = client.get(url)
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": "No text provided - please enter some text before using AI features."
+    }
+
+
+@pytest.mark.django_db
+def test_process_view_post_without_text(client, setup_users):
+    url = reverse("wagtail_ai:process")
+
+    superuser = setup_users
+    client.force_login(superuser)
+
+    response = client.post(url, data={})
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": "No text provided - please enter some text before using AI features."
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("prompt", [None, "NOT-A-UUID", str(uuid.uuid4())])
+def test_process_view_with_bad_prompt_id(client, setup_users, prompt):
+    url = reverse("wagtail_ai:process")
+
+    superuser = setup_users
+    client.force_login(superuser)
+
+    data = {"text": "test"}
+    if prompt is not None:
+        data["prompt"] = prompt
+
+    response = client.post(url, data=data)
+    assert response.status_code == 400
+    assert response.json() == {"error": "Invalid prompt provided"}
+
+
+@pytest.mark.django_db
+def test_process_view_with_correct_prompt(client, setup_users, setup_prompt_object):
+    url = reverse("wagtail_ai:process")
+
+    superuser = setup_users
+    client.force_login(superuser)
+
+    response = client.post(
+        url, data={"text": "test", "prompt": str(setup_prompt_object.uuid)}
+    )
+    assert response.status_code == 200
+    # correct, the tests default is the echo backend
+    assert response.json() == {"message": "This is an echo backend: test"}

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -219,3 +219,5 @@ LOGGING = {
         },
     },
 }
+
+FORMS_URLFIELD_ASSUME_HTTPS = True


### PR DESCRIPTION
This PR:

* adds tests for the prompt view
* tidies up the "no text" error message
* handles the case when the passed prompt id is not a valid UUID
* makes the error messages translatable
* uses a form


Fixes #23