### PR TITLE
Make llm a required dependency

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 1. Install the package along with the relevant client libraries for the default [AI Backend](ai-backends.md):
    ```bash
-   python -m pip install wagtail-ai[llm]
+   python -m pip install wagtail-ai
    ```
 2. Add `wagtail_ai` to your `INSTALLED_APPS`
     ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,11 @@ dynamic = ["version"]
 dependencies = [
     "Django>=4.2",
     "Wagtail>=5.2",
+    "llm>=0.12",
 ]
 requires-python = ">=3.11"
 
 [project.optional-dependencies]
-llm = [
-    "llm>=0.12",
-]
 testing = [
     "dj-database-url==2.1.0",
     "pre-commit>=3.6.0",


### PR DESCRIPTION
Simplify the installation process by always installing the `llm` dependency.