### PR TITLE
Drop backend distinction in testing setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
     strategy:
       matrix:
         python: ['3.11', '3.12', '3.13']
-        backend: ['base', 'llm']
 
     steps:
       - uses: actions/checkout@v5
@@ -93,7 +92,6 @@ jobs:
     strategy:
       matrix:
         python: ['3.11', '3.12', '3.13']
-        backend: ['base', 'llm']
 
     services:
       postgres:

--- a/tests/testapp/test_llm_backend.py
+++ b/tests/testapp/test_llm_backend.py
@@ -6,21 +6,6 @@ from test_utils.settings import custom_ai_backend_class, custom_ai_backend_setti
 
 from wagtail_ai.ai import InvalidAIBackendError, get_ai_backend
 
-try:
-    import llm  # noqa: F401
-except ImportError:
-    llm_installed = False
-else:
-    llm_installed = True
-
-
-skip_if_llm_not_installed = pytest.mark.skipif(
-    not llm_installed, reason="Requires llm to be installed."
-)
-skip_if_llm_installed = pytest.mark.skipif(
-    llm_installed, reason="Requires llm to be not installed."
-)
-
 
 @pytest.fixture
 def llm_backend_class():
@@ -29,27 +14,24 @@ def llm_backend_class():
     return LLMBackend
 
 
-@skip_if_llm_installed
-@custom_ai_backend_class("wagtail_ai.ai.llm.LLMBackend")
+@custom_ai_backend_class("wagtail_ai.ai.nonexistent.LLMBackend")
 def test_import_error():
     with pytest.raises(
         InvalidAIBackendError,
         match=re.escape(
             'Invalid AI backend: "AI backend "default" settings: "CLASS" '
-            '("wagtail_ai.ai.llm.LLMBackend") is not importable.'
+            '("wagtail_ai.ai.nonexistent.LLMBackend") is not importable.'
         ),
     ):
         get_ai_backend("default")
 
 
-@skip_if_llm_not_installed
 @custom_ai_backend_class("wagtail_ai.ai.llm.LLMBackend")
 def test_get_configured_backend_instance(llm_backend_class):
     backend = get_ai_backend("default")
     assert isinstance(backend, llm_backend_class)
 
 
-@skip_if_llm_not_installed
 @custom_ai_backend_settings(
     new_value={
         "CLASS": "wagtail_ai.ai.llm.LLMBackend",
@@ -68,7 +50,6 @@ def test_llm_custom_init_kwargs(llm_backend_class):
     assert llm_model.key == "random-api-key"
 
 
-@skip_if_llm_not_installed
 @custom_ai_backend_settings(
     new_value={
         "CLASS": "wagtail_ai.ai.llm.LLMBackend",

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ usedevelop = True
 
 envlist =
     # Oldest Python, Django, and Wagtail
-    python{3.11}-django{4.2}-wagtail{6.3}-{sqlite,postgres}-{base,llm}
+    python{3.11}-django{4.2}-wagtail{6.3}-{sqlite,postgres}
     # Supported Python with latest LTS releases of Django and Wagtail
-    python{3.11,3.12,3.13}-django{5.2}-wagtail{7.0}-{sqlite,postgres}-{base,llm}
+    python{3.11,3.12,3.13}-django{5.2}-wagtail{7.0}-{sqlite,postgres}
     # Latest stable everything
-    python{3.13}-django{5.2}-wagtail{7.1}-{sqlite,postgres}-{base,llm}
+    python{3.13}-django{5.2}-wagtail{7.1}-{sqlite,postgres}
     # Test against Wagtail's main branch is not done with tox as it would
     # require building Wagtail's static assets due to the use of
     # ManifestStaticFilesStorage. This is done separately in nightly CI.
@@ -23,9 +23,6 @@ python =
 DB =
     sqlite: sqlite
     postgres: postgres
-BACKEND =
-    base: base
-    llm: llm
 
 [testenv]
 pass_env =
@@ -59,11 +56,6 @@ deps =
     postgres: psycopg2>=2.6
 
     .[testing]
-
-[testenv:llm]
-deps =
-    {[testenv]deps}
-    .[llm]
 
 setenv =
     postgres: DATABASE_URL={env:DATABASE_URL:postgres:///wagtail_ai}

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.10: python3.10
     3.11: python3.11
     3.12: python3.12
     3.13: python3.13


### PR DESCRIPTION
Our CI setup was divided into `base` and `llm`, which will install (or not) the `llm` package, and run the tests.

Instead of having a specific settings file for each backend, we decorate the tests in `test_llm_backend.py` to modify the backend settings to use the `llm` backend. We also have a decorator that skips these tests if the package is not installed.

However, as of #55, the `llm` package became a required dependency of the package, which means the package is always installed, so the distinction in the test setup no longer serves its purpose.