### PR TITLE
Add prompt() method to backends and implement contextual alt text feature

### DIFF
--- a/src/wagtail_ai/ai/base.py
+++ b/src/wagtail_ai/ai/base.py
@@ -105,6 +105,12 @@ class AIBackend(Generic[AIBackendConfig], metaclass=ABCMeta):
     ) -> None:
         self.config = config
 
+    def prompt(self, prompt: str, context: dict) -> AIResponse:
+        """
+        Given a prompt and a context, return a response.
+        """
+        raise NotImplementedError("This backend does not support text completion")
+
     def prompt_with_context(
         self, *, pre_prompt: str, context: str, post_prompt: str | None = None
     ) -> AIResponse:

--- a/src/wagtail_ai/ai/echo.py
+++ b/src/wagtail_ai/ai/echo.py
@@ -60,6 +60,10 @@ class EchoBackendConfig(BaseAIBackendConfig[EchoBackendSettingsDict]):
 class EchoBackend(AIBackend[EchoBackendConfig]):
     config_cls = EchoBackendConfig
 
+    def prompt(self, prompt, context):
+        formatted = prompt.format_map(context).split()
+        return self.get_response(["This", "is", "an", "echo", "backend:", *formatted])
+
     def prompt_with_context(
         self, *, pre_prompt: str, context: str, post_prompt: str | None = None
     ) -> AIResponse:

--- a/src/wagtail_ai/ai/llm.py
+++ b/src/wagtail_ai/ai/llm.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, NotRequired, Self
 
 import llm
+from django.core.files import File
 
 from ..types import AIResponse
 from .base import AIBackend, BaseAIBackendConfig, BaseAIBackendConfigSettings
@@ -36,6 +37,24 @@ class LLMBackendConfig(BaseAIBackendConfig[LLMBackendConfigSettingsDict]):
 
 class LLMBackend(AIBackend[LLMBackendConfig]):
     config_cls = LLMBackendConfig
+
+    def prompt(self, prompt, context):
+        model = self.get_llm_model()
+        attachments: list[llm.Attachment] = []
+        for key, value in context.items():
+            if isinstance(value, File):
+                with value.open("rb") as f:
+                    content = f.read()
+                attachments.append(llm.Attachment(content=content))
+                context[key] = f"[file {len(attachments)}]"
+
+        full_prompt = prompt.format_map(context)
+        prompt_kwargs = {}
+        if attachments:
+            prompt_kwargs["attachments"] = attachments
+        if self.config.prompt_kwargs is not None:
+            prompt_kwargs.update(self.config.prompt_kwargs)
+        return model.prompt(full_prompt, **prompt_kwargs)
 
     def prompt_with_context(
         self, *, pre_prompt: str, context: str, post_prompt: str | None = None

--- a/src/wagtail_ai/context.py
+++ b/src/wagtail_ai/context.py
@@ -1,0 +1,87 @@
+import json
+from string import Formatter
+from typing import Any, Type, cast
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.files import File
+from django.utils.translation import gettext as _
+from wagtail.images.models import AbstractImage
+
+
+class PromptContext(dict[str, Any]):
+    """
+    A dict-like object to interpolate a prompt string's placeholders with values.
+    Provides a ``clean()`` method to validate that all placeholders can be handled.
+
+    Validators can be registered with ``register_validator()`` to validate and
+    transform a key's value or provide a fallback.
+
+    A missing key without a registered validator is set as ``{key}`` so
+    ``str.format_map()`` leaves it as-is.
+    """
+
+    validators: dict[str, Any] = {}
+
+    @classmethod
+    def register_validator(cls, name: str, validator):
+        """
+        Register a validator function for a given placeholder key.
+
+        Validator functions should accept a single argument, the context
+        instance, and return the value to use for the key. They can raise
+        ``ValidationError`` if the key is required but invalid or missing from
+        the context.
+        """
+        cls.validators[name] = validator
+
+    def clean(self, prompt: str):
+        """
+        Validate that all placeholder keys in the prompt can be handled.
+        """
+        formatter = Formatter()
+        placeholders = [name for _, name, *_ in formatter.parse(prompt) if name]
+        for key in placeholders:
+            if key in self.validators:
+                # Provide the whole context to the validator to allow it to
+                # access other keys if needed
+                self[key] = self.validators[key](self)
+            elif key not in self:
+                self[key] = "{%s}" % key
+
+
+class PromptJSONDecoder(json.JSONDecoder):
+    """
+    A JSON decoder that uses ``PromptContext`` in place of a plain ``dict``
+    when parsing a JSON object.
+    """
+
+    def __init__(self, *args, object_pairs_hook=PromptContext, **kwargs):
+        super().__init__(*args, object_pairs_hook=object_pairs_hook, **kwargs)
+
+
+def image_id_validator(context) -> File | None:
+    """Fetch a Wagtail image by ID and return its rendition file."""
+    if "image_id" not in context:
+        raise ValidationError(_("The prompt requires an image, but none was provided."))
+    image_id = context["image_id"]
+
+    from wagtail.images import get_image_model
+
+    Image = cast(Type[AbstractImage], get_image_model())
+    try:
+        image = Image._default_manager.get(id=image_id)
+    except Image.DoesNotExist as error:
+        raise ValidationError(
+            _("Could not find image with id %(image_id)s.") % {"image_id": image_id}
+        ) from error
+    wagtail_ai_settings = getattr(settings, "WAGTAIL_AI", {})
+    rendition_filter = wagtail_ai_settings.get(
+        "IMAGE_DESCRIPTION_RENDITION_FILTER", "max-800x600"
+    )
+    rendition = image.get_rendition(rendition_filter)
+    image_file = rendition.file
+    return image_file
+
+
+PromptContext.register_validator("image_id", image_id_validator)

--- a/src/wagtail_ai/forms.py
+++ b/src/wagtail_ai/forms.py
@@ -8,6 +8,8 @@ from wagtail.admin.staticfiles import versioned_static
 from wagtail.images.fields import WagtailImageField
 from wagtail.images.forms import BaseImageForm
 
+from wagtail_ai.models import Prompt
+
 
 class PromptTextField(forms.CharField):
     default_error_messages = {
@@ -40,12 +42,13 @@ class PromptForm(ApiForm):
 
     def clean_prompt(self):
         prompt_uuid = self.cleaned_data["prompt"]
-        if prompt_uuid.version != 4:
+        prompt = Prompt.objects.filter(uuid=prompt_uuid).first()
+        if not prompt:
             raise ValidationError(
                 self.fields["prompt"].error_messages["invalid"], code="invalid"
             )
 
-        return prompt_uuid
+        return prompt
 
 
 class DescribeImageApiForm(ApiForm):

--- a/src/wagtail_ai/prompts.py
+++ b/src/wagtail_ai/prompts.py
@@ -10,6 +10,7 @@ class DefaultPrompt(IntEnum):
     COMPLETION = 2
     DESCRIPTION = 3
     TITLE = 4
+    CONTEXTUAL_ALT_TEXT = 5
 
 
 class PromptDict(TypedDict):
@@ -62,6 +63,26 @@ DEFAULT_PROMPTS: Sequence[PromptDict] = [
             "Create an SEO-friendly page title for the following web page content:\n\n"
             "{content_text}"
         ),
+        "method": "replace",
+    },
+    {
+        "default_prompt_id": DefaultPrompt.CONTEXTUAL_ALT_TEXT,
+        "label": "Contextual alt text",
+        "description": "Generate an alt text for the image with the relevant context",
+        "prompt": """Generate an alt text (and only the text) for the following image: {image_id}
+
+Make the alt text relevant to the following content shown before the image:
+
+---
+{form_context_before}
+---
+
+and also relevant to the following content shown after the image:
+
+---
+{form_context_after}
+---
+""",
         "method": "replace",
     },
 ]

--- a/src/wagtail_ai/prompts.py
+++ b/src/wagtail_ai/prompts.py
@@ -49,7 +49,8 @@ DEFAULT_PROMPTS: Sequence[PromptDict] = [
         "label": "AI Description",
         "description": "Generate a description by summarizing the page content",
         "prompt": (
-            "Create an SEO-friendly meta description of the following web page content:"
+            "Create an SEO-friendly meta description of the following web page content:\n\n"
+            "{content_text}"
         ),
         "method": "replace",
     },
@@ -58,7 +59,8 @@ DEFAULT_PROMPTS: Sequence[PromptDict] = [
         "label": "AI Title",
         "description": "Generate a title based on the page content",
         "prompt": (
-            "Create an SEO-friendly page title for the following web page content:"
+            "Create an SEO-friendly page title for the following web page content:\n\n"
+            "{content_text}"
         ),
         "method": "replace",
     },

--- a/src/wagtail_ai/static_src/constants.ts
+++ b/src/wagtail_ai/static_src/constants.ts
@@ -3,6 +3,7 @@ export enum DefaultPrompt {
   COMPLETION = 2,
   DESCRIPTION = 3,
   TITLE = 4,
+  CONTEXTUAL_ALT_TEXT = 5,
 }
 
 export enum PromptMethod {

--- a/src/wagtail_ai/static_src/custom.d.ts
+++ b/src/wagtail_ai/static_src/custom.d.ts
@@ -1,5 +1,6 @@
 import { Application, Controller } from '@hotwired/stimulus';
 import { DefaultPrompt, PromptMethod } from './constants';
+import { ContextProvider } from './field_panel/main';
 
 /* eslint-disable no-unused-vars */
 export {};
@@ -71,6 +72,7 @@ declare global {
     };
     wagtailAI: {
       config: WagtailAiConfiguration;
+      ContextProvider: ContextProvider;
     };
   }
 

--- a/src/wagtail_ai/static_src/draftail/AIControl.tsx
+++ b/src/wagtail_ai/static_src/draftail/AIControl.tsx
@@ -100,6 +100,7 @@ function AIControl({ getEditorState, onChange }: ControlComponentProps) {
         [
           DefaultPrompt.DESCRIPTION,
           DefaultPrompt.TITLE,
+          DefaultPrompt.CONTEXTUAL_ALT_TEXT,
         ] as Array<DefaultPrompt | null>
       ).includes(prompt.default_prompt_id),
   );

--- a/src/wagtail_ai/views.py
+++ b/src/wagtail_ai/views.py
@@ -89,6 +89,7 @@ def text_completion(request) -> JsonResponse:
         return ErrorJsonResponse(prompt_form.errors_for_json_response(), status=400)
 
     prompt = prompt_form.cleaned_data["prompt"]
+    context = prompt_form.cleaned_data["context"]
 
     handlers = {
         Prompt.Method.REPLACE: _replace_handler,
@@ -98,7 +99,12 @@ def text_completion(request) -> JsonResponse:
     handler = handlers[Prompt.Method(prompt.method)]
 
     try:
-        response = handler(prompt=prompt, text=prompt_form.cleaned_data["text"])
+        if context is None:
+            response = handler(prompt=prompt, text=prompt_form.cleaned_data["text"])
+        else:
+            backend = ai.get_backend()
+            prompt_text = prompt.prompt_value
+            response = backend.prompt(prompt=prompt_text, context=context).text()
     except AIHandlerException as e:
         return ErrorJsonResponse(str(e), status=400)
     except Exception:

--- a/src/wagtail_ai/views.py
+++ b/src/wagtail_ai/views.py
@@ -88,10 +88,7 @@ def text_completion(request) -> JsonResponse:
     if not prompt_form.is_valid():
         return ErrorJsonResponse(prompt_form.errors_for_json_response(), status=400)
 
-    try:
-        prompt = Prompt.objects.get(uuid=prompt_form.cleaned_data["prompt"])
-    except Prompt.DoesNotExist:
-        return ErrorJsonResponse(_("Invalid prompt provided."), status=400)
+    prompt = prompt_form.cleaned_data["prompt"]
 
     handlers = {
         Prompt.Method.REPLACE: _replace_handler,

--- a/tests/backends/test_openai.py
+++ b/tests/backends/test_openai.py
@@ -1,3 +1,4 @@
+import base64
 from typing import cast
 from unittest.mock import ANY, Mock
 
@@ -86,6 +87,57 @@ def test_describe_image(settings, mock_post):
     ]
     url = messages[0]["content"][1]["image_url"]["url"]
     assert url.startswith("data:image/jpeg;base64,")
+
+
+def test_prompt(settings, mock_post):
+    settings.WAGTAIL_AI = {
+        "BACKENDS": {
+            "openai": {
+                "CLASS": "wagtail_ai.ai.openai.OpenAIBackend",
+                "CONFIG": {
+                    "MODEL_ID": "gpt-4",
+                },
+            },
+        },
+    }
+
+    mock_post.return_value.json.return_value = {
+        "choices": [{"message": {"content": MOCK_OUTPUT}}],
+    }
+    backend = get_ai_backend("openai")
+    image = cast(Image, ImageFactory())
+
+    context = {"name": "Gordon", "image": image.file}
+    with image.file.open("rb") as f:
+        content = base64.b64encode(f.read()).decode()
+
+    response = backend.prompt(
+        prompt="My name is {name}. Here's my photo: {image}",
+        context=context,
+    )
+    assert context["image"] == "[file 1]"
+    assert "".join(response) == MOCK_OUTPUT
+    assert response.text() == MOCK_OUTPUT
+
+    headers = mock_post.call_args.kwargs["headers"]
+    assert headers["Authorization"] == f"Bearer {MOCK_API_KEY}"
+
+    messages = mock_post.call_args.kwargs["json"]["messages"]
+    assert messages == [
+        {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "My name is Gordon. Here's my photo: [file 1]",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{content}"},
+                },
+            ],
+            "role": "user",
+        },
+    ]
 
 
 def test_text_completion(settings, mock_post):

--- a/tests/test_ai_backends.py
+++ b/tests/test_ai_backends.py
@@ -1,10 +1,13 @@
 import re
+from typing import cast
 
 import pytest
 from test_utils.settings import (
     custom_ai_backend_class,
     custom_ai_backend_settings,
 )
+from wagtail.images.models import Image
+from wagtail_factories import ImageFactory
 
 from wagtail_ai.ai import (
     BackendNotFound,
@@ -50,6 +53,34 @@ def test_get_backend_instance_with_custom_setting():
     assert backend.config.model_id == "echo"
     assert backend.config.max_word_sleep_seconds == 150
     assert backend.config.token_limit == 123123
+
+
+@custom_ai_backend_settings(
+    new_value={
+        "CLASS": "wagtail_ai.ai.echo.EchoBackend",
+        "CONFIG": {
+            "MODEL_ID": "echo",
+            "TOKEN_LIMIT": 123123,
+            "MAX_WORD_SLEEP_SECONDS": 0,  # type: ignore
+        },
+    }
+)
+@pytest.mark.django_db
+def test_prompt():
+    image = cast(Image, ImageFactory())
+    backend = get_ai_backend("default")
+    context = {"name": "Gordon", "image": image.file}
+    response = backend.prompt(
+        prompt="My name is {name}. Here's my photo: {image}",
+        context=context,
+    )
+    assert response.text() == (
+        "This is an echo backend: "
+        "My name is Gordon. "
+        # This backend does not handle images, so it will just be a string
+        # representation of the image object.
+        f"Here's my photo: {context['image']}"
+    )
 
 
 @custom_ai_backend_settings(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,67 @@
+import json
+from typing import cast
+
+import pytest
+from django.core.exceptions import ValidationError
+from pytest_django import DjangoAssertNumQueries
+from wagtail.images.models import Image
+from wagtail_factories import ImageFactory
+
+from wagtail_ai.context import PromptContext, PromptJSONDecoder
+
+
+def test_missing_key():
+    context = PromptContext(name="Gordon", role="Scientist")
+    prompt = "My name is {name} and I am a {role}. I work at {company}."
+    context.clean(prompt)
+    # company has no validator and is missing, so left as-is
+    assert context["company"] == "{company}"
+    result = prompt.format_map(context)
+    assert result == "My name is Gordon and I am a Scientist. I work at {company}."
+
+
+def test_json_decoder():
+    json_str = '{"name": "Gordon", "role": "Scientist"}'
+    context = json.loads(json_str, cls=PromptJSONDecoder)
+    assert isinstance(context, PromptContext)
+    prompt = "Write an introduction for {name}, a {role}."
+    context.clean(prompt)
+    result = prompt.format_map(context)
+    assert result == "Write an introduction for Gordon, a Scientist."
+
+
+@pytest.mark.django_db
+def test_image_id_validator(django_assert_num_queries: DjangoAssertNumQueries):
+    image = cast(Image, ImageFactory())
+    context = PromptContext(image_id=image.pk)
+    prompt = "Prompt does not use the image_id placeholder."
+    # This will not hit the database as the prompt does not use {image_id}
+    with django_assert_num_queries(0):
+        context.clean(prompt)
+        assert context["image_id"] == image.pk
+    prompt = "Describe the image with ID {image_id}."
+    expected = image.get_rendition("max-800x600").file
+    # This will fetch the image and generate a rendition
+    with django_assert_num_queries(7):
+        context.clean(prompt)
+    # Accessing the result again should not hit the database
+    with django_assert_num_queries(0):
+        assert context["image_id"] == expected
+
+
+def test_image_id_validator_missing():
+    context = PromptContext()
+    with pytest.raises(ValidationError) as exc_info:
+        context.clean("Describe the image with ID {image_id}.")
+    assert (
+        str(exc_info.value.message)
+        == "The prompt requires an image, but none was provided."
+    )
+
+
+@pytest.mark.django_db
+def test_image_id_validator_not_found():
+    context = PromptContext(image_id=9999999)
+    with pytest.raises(ValidationError) as exc_info:
+        context.clean("Describe the image with ID {image_id}.")
+    assert str(exc_info.value.message) == "Could not find image with id 9999999."

--- a/tests/test_utils/settings.py
+++ b/tests/test_utils/settings.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from functools import wraps
 from typing import Any, Literal, cast
 
@@ -15,7 +16,8 @@ def custom_ai_backend_settings(
     def decorator(func):
         @wraps(func)
         def inner(*args, **kwargs):
-            value = {**settings.WAGTAIL_AI}
+            # Use deepcopy to prevent modifying the original settings in place
+            value = deepcopy(settings.WAGTAIL_AI)
             value["BACKENDS"][alias] = new_value
             return override_settings(WAGTAIL_AI=value)(func)(*args, **kwargs)
 

--- a/tests/testapp/test_llm_backend.py
+++ b/tests/testapp/test_llm_backend.py
@@ -1,8 +1,12 @@
 import os
 import re
+from typing import cast
 
+import llm
 import pytest
 from test_utils.settings import custom_ai_backend_class, custom_ai_backend_settings
+from wagtail.images.models import Image
+from wagtail_factories import ImageFactory
 
 from wagtail_ai.ai import InvalidAIBackendError, get_ai_backend
 
@@ -48,6 +52,40 @@ def test_llm_custom_init_kwargs(llm_backend_class):
     assert backend.config.init_kwargs == {"key": "random-api-key"}
     llm_model = backend.get_llm_model()  # type: ignore
     assert llm_model.key == "random-api-key"
+
+
+@pytest.mark.django_db
+@custom_ai_backend_settings(
+    new_value={
+        "CLASS": "wagtail_ai.ai.llm.LLMBackend",
+        "CONFIG": {
+            "MODEL_ID": "gpt-4.1-mini",
+            "PROMPT_KWARGS": {  # type: ignore
+                "system": "This is a test system prompt."
+            },
+        },
+    }
+)
+def test_llm_prompt(mocker):
+    image = cast(Image, ImageFactory())
+    backend = get_ai_backend("default")
+    assert backend.config.prompt_kwargs == {"system": "This is a test system prompt."}
+    prompt_mock = mocker.patch("wagtail_ai.ai.llm.llm.models._Model.prompt")
+
+    context = {"name": "Gordon", "image": image.file}
+    with image.file.open("rb") as f:
+        content = f.read()
+
+    backend.prompt(
+        prompt="My name is {name}. Here's my photo: {image}",
+        context=context,
+    )
+    assert context["image"] == "[file 1]"
+    prompt_mock.assert_called_once_with(
+        "My name is Gordon. Here's my photo: [file 1]",
+        system="This is a test system prompt.",
+        attachments=[llm.Attachment(content=content)],
+    )
 
 
 @custom_ai_backend_settings(

--- a/tests/views/test_text_completion.py
+++ b/tests/views/test_text_completion.py
@@ -40,8 +40,8 @@ def test_process_view_get_request(admin_client):
     response = admin_client.get(url)
     assert response.status_code == 400
     assert response.json() == {
-        "error": "No text provided - please enter some text before using AI features. "
-        "\nInvalid prompt provided."
+        "error": "Invalid prompt provided. "
+        "\nNo text provided - please enter some text before using AI features."
     }
 
 
@@ -51,8 +51,8 @@ def test_process_view_post_without_text(admin_client):
     response = admin_client.post(url, data={})
     assert response.status_code == 400
     assert response.json() == {
-        "error": "No text provided - please enter some text before using AI features. "
-        "\nInvalid prompt provided."
+        "error": "Invalid prompt provided. "
+        "\nNo text provided - please enter some text before using AI features."
     }
 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "lib": ["es2023", "dom"],
+    "lib": ["es2024", "dom"],
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "esModuleInterop": true,
-    "target": "es2023",
+    "target": "es2024",
     "moduleResolution": "node"
   },
   "include": [


### PR DESCRIPTION
Built on #100. Until that PR is merged, it's easier to see the diff by comparing with that branch instead: https://github.com/laymonage/wagtail-ai/compare/feature/suggestions...feature/contextual-alt-text

This adds a `PromptContext` subclass of `dict` that has a registry of "validators" that can validate or provide values for certain keys, given a prompt text. For example, an `image_id` validator is added that would fetch an image with the given ID and return a rendition (and if either the value is missing or the image cannot be found, raises a `ValidationError`). This is used during the cleaning of `PromptForm`, which now accepts an optional `context` `JSONField`. The aim is to eventually remove the `text` field in favour of having an `{input}` in the `Prompt`'s string with the exact placement of the input, instead of always at the end, and with the value supplied as `input` in the `context`.

This also adds a generic `prompt()` method to the backends that accepts two parameters: a `prompt` string and a `context` dictionary. The `prompt` string may contain placeholders in the format of Python string formatting e.g. `"Hello, {name}!"`, and the `context` dictionary will be used to interpolate its values to the string using [`str.format_map()`](https://docs.python.org/3/library/stdtypes.html#str.format_map). Files in the context values are replaced with `[file N]`, with the actual files sent as separate messages after the interpolated prompt. This allows us to adapt how files are handled for each backend, e.g. for `llm` we turn them into `llm.Attachment` objects.

On the client side, we also add a `ContextProvider` mechanism for `FieldPanelController` that is similar to `PromptContext`, but it's more intended for providing the client-side values of placeholders. For example, this is where values for `content_html`, `content_text`, `input`, `image_id`, `max_length`, etc. can come from.

With all this, it is now possible to have a contextual alt text generation inside the editor. For example, with image blocks in bakerydemo: https://github.com/wagtail/bakerydemo/commit/0c2c333137c743fd91041de1258f636ab2bf11fe. This feature also works with the LLM backend, unlike the existing `describe_image` feature which requires OpenAI.

TODO:

- Migrate existing image description feature to use the new `prompt()`
- TBD: Migrate existing rich text features to use the new `prompt()` and suggestions-based UI, which might mean also handling the splitting from the client-side?
- Maybe support https://github.com/mozilla-ai/any-llm?
- Clean up how backend tests are written. It's currently a mess:
  - `base` backend tests are in `tests/test_ai_backends.py`
  - `openai` backend tests are in `tests/backends/test_openai.py`
  - `llm` backend tests are in `tests/testapp/test_llm_backend.py` ???
  - There was a mistake in the test decorators causing the settings to be modified in-place instead of using `override_settings`, which caused the tests to be flaky when run in different order. I've fixed this in one of the commits, but there might be other improvements needed.
- For StreamFields, ensure this still works after reordering/drag and drop