### PR TITLE
Ensure prompts with an empty string can fall back to the default prompt value

### DIFF
--- a/src/wagtail_ai/models.py
+++ b/src/wagtail_ai/models.py
@@ -70,9 +70,9 @@ class Prompt(models.Model, index.Indexed):
         Return the prompt value, otherwise if the prompt is None and belongs
         to the default prompts, map to the default prompt value.
         """
-        if self.prompt is None:
+        if not self.prompt:
             if self.is_default:
                 return self.get_default_prompt_value()
             else:
-                raise ValueError("Prompt value is None and not a default prompt.")
+                raise ValueError("Prompt value is empty and not a default prompt.")
         return self.prompt

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -43,6 +43,11 @@ def test_editing_default_prompts():
     assert default_prompt.prompt is None
     assert prompt_from_get_prompts["prompt"] == default_prompt.prompt_value
 
+    # Saving an empty string should return the default prompt value
+    default_prompt.prompt = ""
+    default_prompt.save()
+    assert default_prompt.prompt_value == DEFAULT_PROMPTS[0]["prompt"]
+
     # Add a prompt value to the default prompt
     default_prompt.prompt = "New Prompt Text"
     default_prompt.save()


### PR DESCRIPTION
Fixes #91.

Not sure if we should also remove `null=True` from the field