### PR TITLE
Allow defining agent providers in WAGTAIL_AI['PROVIDERS'] setting

### DIFF
--- a/src/wagtail_ai/agents/base.py
+++ b/src/wagtail_ai/agents/base.py
@@ -1,24 +1,84 @@
+import warnings
 from functools import cache
 from typing import TYPE_CHECKING, cast
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.dispatch import receiver
+from django.test.signals import setting_changed
 from django.utils.module_loading import import_string
 from django_ai_core.llm import LLMService
 from wagtail.contrib.settings.models import BaseGenericSetting, BaseSiteSetting
 from wagtail.models import Site
 
 from wagtail_ai import ai
+from wagtail_ai.utils.deprecation import WagtailAISettingsDeprecationWarning
 
 if TYPE_CHECKING:
     from wagtail_ai.models import AgentSettingsMixin
 
+_DEFAULT_MODEL_PROVIDER = "openai"
+DEFAULT_PROVIDER_ALIAS = "default"
+
+
+def get_providers() -> dict[str, dict[str, str]]:
+    return getattr(settings, "WAGTAIL_AI", {}).get("PROVIDERS", {})
+
+
+def get_provider(alias=DEFAULT_PROVIDER_ALIAS) -> dict[str, str]:
+    """
+    Get a provider configuration by alias.
+
+    Args:
+        alias: The provider alias to look up
+
+    Returns:
+        Provider configuration dict with ``"provider"`` and ``"model"`` keys,
+        and any other keys to be passed as keyword arguments to the ``LLMService`` constructor.
+
+    Raises:
+        ``ImproperlyConfigured``: If provider not found
+    """
+    providers = get_providers()
+    provider = providers.get(alias)
+
+    # Legacy fallback for backwards compatibility (only for DEFAULT_PROVIDER_ALIAS)
+    if not provider and alias == DEFAULT_PROVIDER_ALIAS:
+        backend = ai.get_backend()
+        model = backend.config.model_id
+        warnings.warn(
+            f"No '{DEFAULT_PROVIDER_ALIAS}' provider configured in "
+            "WAGTAIL_AI['PROVIDERS'], falling back to "
+            f"'{_DEFAULT_MODEL_PROVIDER}' provider with the '{model}' model from "
+            "the default backend's 'MODEL_ID' setting. This fallback behavior is "
+            "deprecated and will be removed in a future release. "
+            "Please configure a default provider in WAGTAIL_AI['PROVIDERS'].",
+            WagtailAISettingsDeprecationWarning,
+            stacklevel=2,
+        )
+        provider = {"provider": _DEFAULT_MODEL_PROVIDER, "model": model}
+        return provider
+
+    if not provider:
+        raise ImproperlyConfigured(
+            f"Provider with alias '{alias}' not found in WAGTAIL_AI['PROVIDERS']."
+        )
+
+    return provider
+
 
 @cache
-def get_llm_service(provider="openai"):
-    # TODO: deprecate the backends and have a proper setting for configuring
-    # the provider and model
-    backend = ai.get_backend()
-    return LLMService.create(provider=provider, model=backend.config.model_id)
+def get_llm_service(alias=DEFAULT_PROVIDER_ALIAS) -> LLMService:
+    """
+    Get an LLM service instance for the given provider alias.
+
+    Args:
+        alias: The provider alias to look up
+
+    Returns:
+        LLMService instance configured with the specified provider
+    """
+    return LLMService.create(**get_provider(alias))
 
 
 def get_agent_settings_model() -> "type[BaseGenericSetting | BaseSiteSetting]":
@@ -39,3 +99,9 @@ def get_agent_settings() -> "AgentSettingsMixin":
         settings = model.load()
 
     return cast("AgentSettingsMixin", settings)
+
+
+@receiver(setting_changed)
+def clear_caches_on_setting_change(sender, setting, **kwargs):
+    if setting == "WAGTAIL_AI":
+        get_llm_service.cache_clear()

--- a/src/wagtail_ai/agents/content_feedback.py
+++ b/src/wagtail_ai/agents/content_feedback.py
@@ -78,6 +78,7 @@ class ContentFeedbackAgent(Agent):
             ),
         ),
     ]
+    provider_alias = "default"
     _response_format = ContentFeedbackSchema
 
     def execute(
@@ -136,7 +137,7 @@ Return JSON with the provided structure WITHOUT the markdown code block. Start i
         return messages
 
     def _get_result(self, messages: list[dict]) -> dict:
-        client = get_llm_service()
+        client = get_llm_service(alias=self.provider_alias)
         result = client.completion(
             messages=messages,
             response_format=self._response_format,

--- a/src/wagtail_ai/wagtail_hooks.py
+++ b/src/wagtail_ai/wagtail_hooks.py
@@ -6,6 +6,7 @@ from django.template.loader import render_to_string
 from django.urls import include, path, reverse
 from django.utils.html import format_html, json_script
 from django.views.i18n import JavaScriptCatalog
+from django_ai_core.contrib.agents import registry
 from wagtail import hooks
 from wagtail.admin.rich_text.editors.draftail.features import ControlFeature
 from wagtail.admin.staticfiles import versioned_static
@@ -13,14 +14,15 @@ from wagtail.contrib.settings.models import register_setting
 
 from wagtail_ai.agents.base import get_agent_settings_model
 
-from .agents.content_feedback import ContentFeedbackAgent
-from .agents.suggested_content import SuggestedContentAgent
 from .models import Prompt
 from .views import describe_image, prompt_viewset, text_completion
 
 
 @hooks.register("register_admin_urls")  # type: ignore
 def register_admin_urls():
+    content_feedback_agent = registry.get("wai_content_feedback")
+    suggested_content_agent = registry.get("wai_suggested_content")
+
     urls = [
         path(
             "jsi18n/",
@@ -39,12 +41,12 @@ def register_admin_urls():
         ),
         path(
             "content_feedback/",
-            ContentFeedbackAgent.as_view(),
+            content_feedback_agent.as_view(),
             name="content_feedback",
         ),
         path(
             "suggested-content/",
-            SuggestedContentAgent.as_view(),
+            suggested_content_agent.as_view(),
             name="suggested_content",
         ),
     ]

--- a/src/wagtail_ai/wagtail_hooks.py
+++ b/src/wagtail_ai/wagtail_hooks.py
@@ -45,7 +45,7 @@ def register_admin_urls():
             name="content_feedback",
         ),
         path(
-            "suggested-content/",
+            "suggested_content/",
             suggested_content_agent.as_view(),
             name="suggested_content",
         ),

--- a/tests/agents/test_base.py
+++ b/tests/agents/test_base.py
@@ -1,0 +1,184 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from wagtail_ai.agents.base import get_llm_service, get_provider
+
+
+class TestGetProvider:
+    def test_returns_provider_by_alias(self, settings):
+        settings.WAGTAIL_AI = {
+            "PROVIDERS": {
+                "default": {"provider": "openai", "model": "gpt-4o-mini"},
+                "premium": {"provider": "anthropic", "model": "claude-3-5-sonnet"},
+            }
+        }
+        provider = get_provider("premium")
+        assert provider == {"provider": "anthropic", "model": "claude-3-5-sonnet"}
+
+    def test_returns_default_provider_when_alias_not_explicit(self, settings):
+        settings.WAGTAIL_AI = {
+            "PROVIDERS": {
+                "default": {"provider": "openai", "model": "gpt-4o-mini"},
+            }
+        }
+        provider = get_provider()
+        assert provider == {"provider": "openai", "model": "gpt-4o-mini"}
+
+    def test_raises_error_when_alias_not_found(self, settings):
+        settings.WAGTAIL_AI = {
+            "PROVIDERS": {
+                "default": {"provider": "openai", "model": "gpt-4o-mini"},
+            }
+        }
+        with pytest.raises(ImproperlyConfigured) as exc_info:
+            get_provider("premium")
+        assert "Provider with alias 'premium' not found" in str(exc_info.value)
+
+    def test_legacy_fallback_for_default_provider(self, settings):
+        """Test the deprecated fallback behavior when default provider not configured."""
+        settings.WAGTAIL_AI = {
+            "BACKENDS": {
+                "default": {
+                    "CLASS": "wagtail_ai.ai.echo.EchoBackend",
+                    "CONFIG": {"MODEL_ID": "echo-model"},
+                }
+            }
+        }
+
+        with patch("wagtail_ai.agents.base.ai.get_backend") as mock_get_backend:
+            mock_backend = MagicMock()
+            mock_backend.config.model_id = "echo-model"
+            mock_get_backend.return_value = mock_backend
+
+            with pytest.warns(match="No 'default' provider configured.*deprecated"):
+                provider = get_provider("default")
+
+            assert provider == {"provider": "openai", "model": "echo-model"}
+
+    def test_provider_with_extra_config(self, settings):
+        """Test that extra configuration keys are preserved."""
+        settings.WAGTAIL_AI = {
+            "PROVIDERS": {
+                "default": {
+                    "provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "api_base": "https://api.example.com",
+                }
+            }
+        }
+        provider = get_provider("default")
+        assert provider == {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_base": "https://api.example.com",
+        }
+
+
+class TestGetLLMService:
+    def test_returns_llm_service_for_default_provider(self, settings):
+        settings.WAGTAIL_AI = {
+            "PROVIDERS": {
+                "default": {"provider": "openai", "model": "gpt-4o-mini"},
+            }
+        }
+
+        with patch("wagtail_ai.agents.base.LLMService.create") as mock_create:
+            mock_service = MagicMock()
+            mock_create.return_value = mock_service
+
+            service = get_llm_service()
+
+            mock_create.assert_called_once_with(provider="openai", model="gpt-4o-mini")
+            assert service == mock_service
+
+    def test_returns_llm_service_for_specific_alias(self, settings):
+        settings.WAGTAIL_AI = {
+            "PROVIDERS": {
+                "default": {"provider": "openai", "model": "gpt-4o-mini"},
+                "premium": {"provider": "anthropic", "model": "claude-3-5-sonnet"},
+            }
+        }
+
+        with patch("wagtail_ai.agents.base.LLMService.create") as mock_create:
+            mock_service = MagicMock()
+            mock_create.return_value = mock_service
+
+            service = get_llm_service("premium")
+
+            mock_create.assert_called_once_with(
+                provider="anthropic", model="claude-3-5-sonnet"
+            )
+            assert service == mock_service
+
+    def test_caches_service_for_same_alias(self, settings):
+        settings.WAGTAIL_AI = {
+            "PROVIDERS": {
+                "default": {"provider": "openai", "model": "gpt-4o-mini"},
+            }
+        }
+
+        with patch("wagtail_ai.agents.base.LLMService.create") as mock_create:
+            mock_service = MagicMock()
+            mock_create.return_value = mock_service
+
+            # Call twice with same alias
+            service1 = get_llm_service("default")
+            service2 = get_llm_service("default")
+
+            # Should only create once due to caching
+            mock_create.assert_called_once()
+            assert service1 is service2
+
+    def test_creates_different_services_for_different_aliases(self, settings):
+        settings.WAGTAIL_AI = {
+            "PROVIDERS": {
+                "default": {"provider": "openai", "model": "gpt-4o-mini"},
+                "premium": {"provider": "anthropic", "model": "claude-3-5-sonnet"},
+            }
+        }
+
+        with patch("wagtail_ai.agents.base.LLMService.create") as mock_create:
+            mock_service1 = MagicMock()
+            mock_service2 = MagicMock()
+            mock_create.side_effect = [mock_service1, mock_service2]
+
+            service1 = get_llm_service("default")
+            service2 = get_llm_service("premium")
+
+            assert mock_create.call_count == 2
+            assert service1 is not service2
+
+    def test_raises_error_when_provider_not_found(self, settings):
+        settings.WAGTAIL_AI = {
+            "PROVIDERS": {
+                "default": {"provider": "openai", "model": "gpt-4o-mini"},
+            }
+        }
+
+        with pytest.raises(ImproperlyConfigured):
+            get_llm_service("nonexistent")
+
+    def test_passes_extra_config_to_llm_service(self, settings):
+        settings.WAGTAIL_AI = {
+            "PROVIDERS": {
+                "default": {
+                    "provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "api_base": "https://api.example.com",
+                }
+            }
+        }
+
+        with patch("wagtail_ai.agents.base.LLMService.create") as mock_create:
+            mock_service = MagicMock()
+            mock_create.return_value = mock_service
+
+            get_llm_service()
+
+            mock_create.assert_called_once_with(
+                provider="openai",
+                model="gpt-4o-mini",
+                api_base="https://api.example.com",
+            )

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -187,6 +187,12 @@ if os.environ.get("WAGTAIL_AI_DEFAULT_BACKEND") == "chatgpt":
                 },
             },
         },
+        "PROVIDERS": {
+            "default": {
+                "provider": "openai",
+                "model": "gpt-4.1-mini",
+            },
+        },
         "IMAGE_DESCRIPTION_BACKEND": "vision",
     }
 
@@ -200,6 +206,12 @@ else:
                     "MAX_WORD_SLEEP_SECONDS": 1,
                     "TOKEN_LIMIT": 100,
                 },
+            },
+        },
+        "PROVIDERS": {
+            "default": {
+                "provider": "foo",
+                "model": "bar",
             },
         },
         "IMAGE_DESCRIPTION_BACKEND": "default",


### PR DESCRIPTION
Example Scaleway usage:

```py
WAGTAIL_AI = {
    ....
    "PROVIDERS": {
        "default": {
            "provider": "openai",
            "model": "gpt-oss-120b",
            "api_key": os.environ.get("SCW_SECRET_KEY", ""),
            "api_base": os.environ.get(
                "SCW_API_BASE",
                f"https://api.scaleway.ai/{os.environ.get('SCW_DEFAULT_PROJECT_ID')}/v1/",
            ),
        }
    },
}
```