### PR TITLE
Properly handle optional chunkSize in AIMultipleChooserPanel

### DIFF
--- a/src/wagtail_ai/panels.py
+++ b/src/wagtail_ai/panels.py
@@ -113,7 +113,8 @@ class AIChooserPanelMixin(Panel):
             )
             attrs["data-wai-chooser-panel-limit-value"] = self.panel.suggest_limit
             attrs["data-wai-chooser-panel-vector-index-value"] = self.panel.vector_index
-            attrs["data-wai-chooser-panel-chunk-size-value"] = self.panel.chunk_size
+            if self.panel.chunk_size:
+                attrs["data-wai-chooser-panel-chunk-size-value"] = self.panel.chunk_size
             return attrs
 
         def get_context_data(self, parent_context=None):

--- a/src/wagtail_ai/static_src/chooser_panel/main.ts
+++ b/src/wagtail_ai/static_src/chooser_panel/main.ts
@@ -39,6 +39,7 @@ class ChooserPanelController extends Controller<HTMLElement> {
   declare seenPksValue: [string?];
   declare stateValue: ChooserSuggestionState;
   declare chunkSizeValue: number;
+  declare hasChunkSizeValue: boolean;
   declare suggestButtonTarget: HTMLButtonElement;
   abortController: AbortController | null = null;
   #panelComponent: any | null = null;
@@ -112,7 +113,9 @@ class ChooserPanelController extends Controller<HTMLElement> {
             ],
             content: innerText,
             limit: limit,
-            chunk_size: this.chunkSizeValue,
+            chunk_size: this.hasChunkSizeValue
+              ? this.chunkSizeValue
+              : undefined,
           },
         }),
         signal: this.abortController?.signal,


### PR DESCRIPTION
Previously, the data attribute will be set to 'None'.

Then, when the value is accessed in Stimulus, it returns NaN, which becomes null when serialized.

With this change, the attribute is now only set if chunk_size is set on the panel, and the request body only includes chunk_size in the arguments if the value exists on the controller