### PR TITLE
:pencil: Fix clone URL in contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,7 +5,7 @@
 To make changes to this project, first clone this repository:
 
 ```shell
-git clone https://github.com/wagtail-ai/wagtail-ai.git
+git clone https://github.com/wagtail/wagtail-ai.git
 cd wagtail-ai
 ```
 


### PR DESCRIPTION
Just a small typo, but it's in a place that might confuse people (like myself). 