### PR TITLE
Closes #162 - guess appropriate mime type when uploading an image

### DIFF
--- a/src/wagtail_ai/agents/basic_prompt.py
+++ b/src/wagtail_ai/agents/basic_prompt.py
@@ -1,4 +1,5 @@
 import base64
+import mimetypes
 from abc import ABC
 from urllib.parse import SplitResult
 
@@ -124,10 +125,12 @@ class BasicPromptAgent(Agent):
         for key, value in self.context.items():
             if isinstance(value, (File, SplitResult)):
                 if isinstance(value, File):
-                    # TODO: check the file type and handle accordingly
+                    mime_type, _ = mimetypes.guess_type(value.name)
+                    if not mime_type:
+                        mime_type = "image/jpeg"
                     with value.open() as f:
                         base64_image = base64.b64encode(f.read()).decode()
-                    url = f"data:image/jpeg;base64,{base64_image}"
+                    url = f"data:{mime_type};base64,{base64_image}"
                 else:
                     # Assume it's a data URL for an image
                     url = value.geturl()

--- a/src/wagtail_ai/ai/openai.py
+++ b/src/wagtail_ai/ai/openai.py
@@ -1,4 +1,5 @@
 import base64
+import mimetypes
 import os
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -77,6 +78,9 @@ class OpenAIBackend(AIBackend[OpenAIBackendConfig]):
     def describe_image(self, *, image_file: File, prompt: str) -> OpenAIResponse:
         if not prompt:
             raise ValueError("Prompt must not be empty.")
+        mime_type, _ = mimetypes.guess_type(image_file.name)
+        if not mime_type:
+            mime_type = "image/jpeg"
         with image_file.open() as f:
             base64_image = base64.b64encode(f.read()).decode("utf-8")
 
@@ -92,7 +96,7 @@ class OpenAIBackend(AIBackend[OpenAIBackendConfig]):
                         {
                             "type": "image_url",
                             "image_url": {
-                                "url": f"data:image/jpeg;base64,{base64_image}"
+                                "url": f"data:{mime_type};base64,{base64_image}"
                             },
                         },
                     ],


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #162 

### Description

<!-- Please describe the problem you're fixing. -->
Sniffs file extension using `mimetypes.guess_type`, uses that to label the uploaded blob

### AI usage

AI helped me explore the source code and evaluate different solves. Also generated this solution, but I have read and understood it comprehensively. All 20-ish lines of it.